### PR TITLE
fix: add siteUrl to siteMetadata

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -24,7 +24,10 @@ const siteMetadata = fs.existsSync(dataDir)
   : {};
 
 const config: GatsbyConfig = {
-  siteMetadata,
+  siteMetadata: {
+    ...siteMetadata,
+    siteUrl: "https://pkch93.github.io",
+  },
   // More easily incorporate content into your pages through automatic TypeScript type generation and better GraphQL IntelliSense.
   // If you use VSCode you can also use the GraphQL plugin
   // Learn more at: https://gatsby.dev/graphql-typegen


### PR DESCRIPTION
This change fixes a build error caused by gatsby-plugin-sitemap. The plugin requires siteUrl to be defined in siteMetadata, which was missing because it's populated dynamically from YAML files. By appending siteUrl to the siteMetadata object in gatsby-config.ts, the build succeeds.

---
*PR created automatically by Jules for task [139550514665100253](https://jules.google.com/task/139550514665100253) started by @pkch93*